### PR TITLE
修正 jpeg 符号和模板中 DJ 音标的链接

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 提交 PR 请尽量遵循以下条目:
 
-1. 音标以[海词](http://dict.cn/)的英式发音为主, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/KK%E9%9F%B3%E6%A8%99).
+1. 音标以[海词](http://dict.cn/)的英式发音为主, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99).
 2. 音频地址格式为 http://dict.youdao.com/dictvoice?audio=${word}&type=2, 如果没有或者发音不准确再使用其他音频.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | integer [🔊](http://dict.youdao.com/dictvoice?audio=integer&type=1) | ✅ ['ɪntɪdʒə] | ❌ [ˈɪntaɪgə] |
 | issue [🔊](http://dict.youdao.com/dictvoice?audio=issue&type=1) | ✅ ['ɪʃuː] | ❌ [ˈaɪʃuː] |
 | Java [🔊](http://dict.youdao.com/dictvoice?audio=java&type=1) | ✅ ['dʒɑːvə] | ❌ ['dʒɑːvɑː] |
-| jpg(jpeg) [🔊](http://dict.youdao.com/dictvoice?audio=JPEG&type=1) | ✅ ['dʒeɪpeɡ] | [ˈdʒeɪˈpi:ˈdʒiː] |
+| jpg(jpeg) [🔊](http://dict.youdao.com/dictvoice?audio=JPEG&type=1) | ✅ ['dʒeɪpeɡ] | ❌ [ˈdʒeɪˈpi:ˈdʒiː] |
 | Linux [🔊](http://dict.youdao.com/dictvoice?audio=linux&type=1) | ✅ ['lɪnəks] | ❌ [ˈlɪnʌks; ˈlɪnjuːks] |
 | main [🔊](http://dict.youdao.com/dictvoice?audio=main&type=1) | ✅ [meɪn] | ❌ [mɪn] |
 | margin [🔊](http://dict.youdao.com/dictvoice?audio=margin&type=1) | ✅ ['mɑːdʒɪn] | ❌ ['mʌgɪn] |


### PR DESCRIPTION
修正 jpeg 符号和模板中 DJ 音标的链接

建议为有多种正确发音的单词建立一种格式，如果将多个正确发音塞入一个单元格，样式会不好看，比如 SQL 的正确发音有 S-Q-L 和 Sequel，以及 GUI 的正确发音有 Gee-Yu-Eye 和 Gooey