### PR TITLE
Modified the audio resource URL for GNU

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | facade [🔊](http://dict.youdao.com/dictvoice?audio=facade&type=1) | ✅ [fə'sɑːd]]| ❌ ['feikeid] |
 | fedora [🔊](http://dict.youdao.com/dictvoice?audio=fedora&type=1) | ✅ [fɪ'dɔːrə]| ❌ ['fedərə] |
 | Git [🔊](http://dict.youdao.com/dictvoice?audio=git&type=1) | ✅ [ɡɪt] | ❌ [dʒɪt; jɪt] |
-| GNU [🔊](http://dict.youdao.com/dictvoice?audio=GNU&type=1) | ✅ [gnu:] | |
+| GNU [🔊](https://upload.wikimedia.org/wikipedia/commons/2/24/En-gnu.ogg) | ✅ [gnu:] | |
 | GUI [🔊](http://dict.youdao.com/dictvoice?audio=GUI&type=1) | ✅ [ˈɡui] | |
 | height [🔊](http://dict.youdao.com/dictvoice?audio=height&type=1) | ✅ [haɪt] | ❌ [heɪt] |
 | hidden [🔊](http://dict.youdao.com/dictvoice?audio=hidden&type=1) | ✅ ['hɪdn] | ❌ ['haɪdn] |


### PR DESCRIPTION
The pronunciation in the original audio resource for GNU is the same to "new",
but it should be read as /gnuː/ instead of "new"(/njuː/),  according to the article in [Wikipedia](https://en.wikipedia.org/wiki/GNU).
Really sorry for not providing a proper online audio URL from youdao, because I couldn't even find a proper online audio resource for the word GNU.
#132 