### PR TITLE
Check the pronounciation of Ubuntu on WIKI and upload its audio source

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 | sudo | ✅ ['suːduː] | |
 | suite [🔊](http://dict.youdao.com/dictvoice?audio=suite&type=1) | ✅ [swiːt] | ❌ [sjuːt] |
 | typical [🔊](http://dict.youdao.com/dictvoice?audio=typical&type=1) | ✅ ['tɪpɪkl] | ❌ ['taɪpɪkəl] |
-| Ubuntu [🔊](http://dict.youdao.com/dictvoice?audio=ubuntu&type=1) | ✅ [ʊ'bʊntʊ] | ❌ [juː'bʊntʊ] |
+| Ubuntu [🔊](http://upload.wikimedia.org/wikipedia/commons/b/b5/En-Ubuntu_pronunciation.oga) | ✅ [ʊ'bʊntʊ] | ❌ [juː'bʊntʊ] |
 | variable [🔊](http://dict.youdao.com/dictvoice?audio=variable&type=1) | ✅ ['veəriəbl] | ❌ [və'raiəbl] |
 | vue [🔊](http://dict.youdao.com/dictvoice?audio=vue&type=1) | ✅ [v'ju:] | ❌ [v'ju:i] |
 | width [🔊](http://dict.youdao.com/dictvoice?audio=width&type=1) | ✅ [wɪdθ] | ❌ [waɪdθ] |


### PR DESCRIPTION
查找了Ubuntu的发音，发现原先有道的发音是不准确的，因此替换为了[wikipedia](https://upload.wikimedia.org/wikipedia/commons/b/b5/En-Ubuntu_pronunciation.oga)提供的发音，主要参考来源是以下三处：
1. [How To Pronounce "Ubuntu"](https://www.youtube.com/watch?v=8EADF3TCaK4)
2. https://www.ubuntu.com/about （上面视频中提到的官方提示）
3. https://en.wikipedia.org/wiki/Ubuntu
