### PR TITLE
Add a wrong pronunication of "OS X".

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 | module [🔊](http://dict.youdao.com/dictvoice?audio=module&type=1) | ✅ ['mɒdjuːl] | ❌ ['məʊdl] |
 | nginx | ✅ Engine X | |
 | null [🔊](http://dict.youdao.com/dictvoice?audio=null&type=1) | ✅ [nʌl] | ❌ [naʊ] |
-| OS X | ✅ OS ten | |
+| OS X | ✅ OS ten | ❌ [ɔs eks] |
 | phantom [🔊](http://dict.youdao.com/dictvoice?audio=phantom&type=2) | ✅ ['fæntəm] | ❌ ['pæntəm] |
 | parameter [🔊](http://dict.youdao.com/dictvoice?audio=parameter&type=1) | ✅ [pə'ræmɪtə] | ❌ ['pærəmɪtə] |
 | privilege [🔊](http://dict.youdao.com/dictvoice?audio=privilege&type=1) | ✅ ['prɪvəlɪdʒ] | ❌ ['prɪvɪlɪdʒ] |


### PR DESCRIPTION
提交 PR 请尽量遵循以下条目:

1. 音标以[海词](http://dict.cn/)的英式发音为主, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99).
2. 音频地址格式为 http://dict.youdao.com/dictvoice?audio=${word}&type=2, 如果没有或者发音不准确再使用其他音频.
