### PR TITLE
ref: 🔊 语音链接改用 https

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,109 +3,109 @@
 
 | 单词 | 正确发音（英音）| 正确发音（美音）| 错误发音 |
 | --- | ----------- | ----------- | ---------- |
-| access | [🔊](http://dict.youdao.com/dictvoice?audio=access&type=1)  /'ækses/ | [🔊](http://dict.youdao.com/dictvoice?audio=access&type=2)  /ˈækses/ |  ❌ /ək'ses/ |
-| Adobe | [🔊](http://dict.youdao.com/dictvoice?audio=Adobe&type=1)  /ə'dəʊbi/ | [🔊](http://dict.youdao.com/dictvoice?audio=Adobe&type=2)  /ə'dəʊbi/ |  ❌ /əˈdub/ |
-| admin | [🔊](http://dict.youdao.com/dictvoice?audio=admin&type=1)  /'ædmɪn/ | [🔊](http://dict.youdao.com/dictvoice?audio=admin&type=2)  /ˈædmɪn/ |  ❌ /ɜ:d'mɪn/ |
-| adversarial | [🔊](http://dict.youdao.com/dictvoice?audio=adversarial&type=1)  /ˌædvəˈseəriəl/ | [🔊](http://dict.youdao.com/dictvoice?audio=adversarial&type=2)   /ˌædvərˈseriəl/ |  ❌ /ədˈvɜːrsəriəl/ |
-| agile | [🔊](http://dict.youdao.com/dictvoice?audio=agile&type=1)  /'ædʒaɪl/ | [🔊](http://dict.youdao.com/dictvoice?audio=agile&type=2)  /ˈædʒl/ |  ❌ /ə'dʒaɪl/ |
-| amazon | [🔊](http://dict.youdao.com/dictvoice?audio=amazon&type=1)  /'æməzən/ | [🔊](http://dict.youdao.com/dictvoice?audio=amazon&type=2)  /ˈæməzɑːn/ |  ❌ /'əmeizən/ /ə'meizən/ |
-| analogy | [🔊](http://dict.youdao.com/dictvoice?audio=analogy&type=1)  /əˈnælədʒi/ | [🔊](http://dict.youdao.com/dictvoice?audio=analogy&type=2)  /əˈnælədʒi/ |  ❌ /ænə'lɒdʒi/ |
-| Angular | [🔊](http://dict.youdao.com/dictvoice?audio=Angular&type=1)  /'æŋgjʊlə/ | [🔊](http://dict.youdao.com/dictvoice?audio=Angular&type=2)  /ˈæŋɡjələr/ |  ❌ /'æŋɡələ/ /'æŋdʒʌlə/ |
-| AJAX | [🔊](http://dict.youdao.com/dictvoice?audio=AJAX&type=1)  /'eidʒæks/ | [🔊](http://dict.youdao.com/dictvoice?audio=AJAX&type=2)  /'eidʒæks/ |  ❌ /ə'dʒʌks/ |
-| alias | [🔊](http://dict.youdao.com/dictvoice?audio=alias&type=1)  /ˈeɪliəs/ | [🔊](http://dict.youdao.com/dictvoice?audio=alias&type=2)  /ˈeɪliəs/ |  ❌ /ə'lais/ |
-| Apache | [🔊](http://dict.youdao.com/dictvoice?audio=Apache&type=1)  /ə'pætʃɪ/ | [🔊](http://dict.youdao.com/dictvoice?audio=Apache&type=2)  /əˈpætʃi/ |  ❌ /ʌpʌtʃ/ |
-| app | [🔊](http://dict.youdao.com/dictvoice?audio=app&type=1)  /æp/ | [🔊](http://dict.youdao.com/dictvoice?audio=app&type=2)  /æp/ |  ❌ /eipi'pi/ |
-| archive | [🔊](http://dict.youdao.com/dictvoice?audio=archive&type=1)  /'ɑːkaɪv/ | [🔊](http://dict.youdao.com/dictvoice?audio=archive&type=2)  /'ɑːkaɪv/ |  ❌ /'ətʃɪv/ |
-| array | [🔊](http://dict.youdao.com/dictvoice?audio=array&type=1)  /ə'rei/ | [🔊](http://dict.youdao.com/dictvoice?audio=array&type=2)  /əˈreɪ/ |  ❌ /æ'rei/ |
-| ASCII | [🔊](http://dict.youdao.com/dictvoice?audio=ascii&type=1)  /'æski/ | [🔊](http://dict.youdao.com/dictvoice?audio=ascii&type=2)  /ˈæski/ |  ❌ /ɑːsk/ |
-| aspect | [🔊](http://dict.youdao.com/dictvoice?audio=aspect&type=1)  /'æspekt/ | [🔊](http://dict.youdao.com/dictvoice?audio=aspect&type=2)  /ˈæspekt/ |  ❌ /ə'spekt/ |
-| avatar | [🔊](http://dict.youdao.com/dictvoice?audio=avatar&type=1)  /'ævətɑː/ | [🔊](http://dict.youdao.com/dictvoice?audio=avatar&type=2)  /ˈævətɑːr/ |  ❌ /ə'vʌtɑ/ |
-| Azure | [🔊](http://dict.youdao.com/dictvoice?audio=azure&type=1)  /'æʒə/ | [🔊](http://dict.youdao.com/dictvoice?audio=azure&type=2)  /ˈæʒər/ |  ❌ /ˈæzʊʒə/ |
-| bind | [🔊](http://dict.youdao.com/dictvoice?audio=bind&type=1)  /baɪnd/ | [🔊](http://dict.youdao.com/dictvoice?audio=bind&type=2)  /baɪnd/ |  ❌ /bɪnd/ |
-| cache | [🔊](http://dict.youdao.com/dictvoice?audio=cache&type=1)  /kæʃ/ | [🔊](http://dict.youdao.com/dictvoice?audio=cache&type=2)  /kæʃ/ |  ❌ /kætʃ/ |
-| clang | [🔊](http://dict.youdao.com/dictvoice?audio=clang&type=1)  /klæŋ/ | [🔊](http://dict.youdao.com/dictvoice?audio=clang&type=2)  /klæŋ/ |  ❌ /sɪlæŋ/ |
-| daemon | [🔊](http://dict.youdao.com/dictvoice?audio=Daemon&type=1)  /'diːmən/ | [🔊](http://dict.youdao.com/dictvoice?audio=Daemon&type=2)  /ˈdiːmən/ |  ❌ /dæmən/ |
-| debt | [🔊](http://dict.youdao.com/dictvoice?audio=debt&type=1)  /det/ | [🔊](http://dict.youdao.com/dictvoice?audio=debt&type=2)  /det/ |  ❌ /de'bit/ |
-| deny | [🔊](http://dict.youdao.com/dictvoice?audio=deny&type=1)  /dɪ'naɪ/ | [🔊](http://dict.youdao.com/dictvoice?audio=deny&type=2)  /dɪˈnaɪ/ |  ❌ /'dæni/ |
-| deprecate | [🔊](http://dict.youdao.com/dictvoice?audio=deprecate&type=1) /ˈdeprəkeɪt/ | [🔊](http://dict.youdao.com/dictvoice?audio=deprecate&type=2) /ˈdeprəkeɪt/ |  |
-| deque | [🔊](http://dict.youdao.com/dictvoice?audio=deque&type=1)  /'dek/ | [🔊](http://dict.youdao.com/dictvoice?audio=deque&type=2)  /dɛk/ |  ❌ /di'kju/ |
-| digest | [🔊](http://dict.youdao.com/dictvoice?audio=digest&type=1)  n. /'dɑɪdʒɛst/ v. /dɑɪ'dʒɛst/ | [🔊](http://dict.youdao.com/dictvoice?audio=digest&type=2)  /daɪˈdʒest,dɪˈdʒest/ |  ❌ /'dɪgɛst/ |
+| access | [🔊](https://dict.youdao.com/dictvoice?audio=access&type=1)  /'ækses/ | [🔊](https://dict.youdao.com/dictvoice?audio=access&type=2)  /ˈækses/ |  ❌ /ək'ses/ |
+| Adobe | [🔊](https://dict.youdao.com/dictvoice?audio=Adobe&type=1)  /ə'dəʊbi/ | [🔊](https://dict.youdao.com/dictvoice?audio=Adobe&type=2)  /ə'dəʊbi/ |  ❌ /əˈdub/ |
+| admin | [🔊](https://dict.youdao.com/dictvoice?audio=admin&type=1)  /'ædmɪn/ | [🔊](https://dict.youdao.com/dictvoice?audio=admin&type=2)  /ˈædmɪn/ |  ❌ /ɜ:d'mɪn/ |
+| adversarial | [🔊](https://dict.youdao.com/dictvoice?audio=adversarial&type=1)  /ˌædvəˈseəriəl/ | [🔊](https://dict.youdao.com/dictvoice?audio=adversarial&type=2)   /ˌædvərˈseriəl/ |  ❌ /ədˈvɜːrsəriəl/ |
+| agile | [🔊](https://dict.youdao.com/dictvoice?audio=agile&type=1)  /'ædʒaɪl/ | [🔊](https://dict.youdao.com/dictvoice?audio=agile&type=2)  /ˈædʒl/ |  ❌ /ə'dʒaɪl/ |
+| amazon | [🔊](https://dict.youdao.com/dictvoice?audio=amazon&type=1)  /'æməzən/ | [🔊](https://dict.youdao.com/dictvoice?audio=amazon&type=2)  /ˈæməzɑːn/ |  ❌ /'əmeizən/ /ə'meizən/ |
+| analogy | [🔊](https://dict.youdao.com/dictvoice?audio=analogy&type=1)  /əˈnælədʒi/ | [🔊](https://dict.youdao.com/dictvoice?audio=analogy&type=2)  /əˈnælədʒi/ |  ❌ /ænə'lɒdʒi/ |
+| Angular | [🔊](https://dict.youdao.com/dictvoice?audio=Angular&type=1)  /'æŋgjʊlə/ | [🔊](https://dict.youdao.com/dictvoice?audio=Angular&type=2)  /ˈæŋɡjələr/ |  ❌ /'æŋɡələ/ /'æŋdʒʌlə/ |
+| AJAX | [🔊](https://dict.youdao.com/dictvoice?audio=AJAX&type=1)  /'eidʒæks/ | [🔊](https://dict.youdao.com/dictvoice?audio=AJAX&type=2)  /'eidʒæks/ |  ❌ /ə'dʒʌks/ |
+| alias | [🔊](https://dict.youdao.com/dictvoice?audio=alias&type=1)  /ˈeɪliəs/ | [🔊](https://dict.youdao.com/dictvoice?audio=alias&type=2)  /ˈeɪliəs/ |  ❌ /ə'lais/ |
+| Apache | [🔊](https://dict.youdao.com/dictvoice?audio=Apache&type=1)  /ə'pætʃɪ/ | [🔊](https://dict.youdao.com/dictvoice?audio=Apache&type=2)  /əˈpætʃi/ |  ❌ /ʌpʌtʃ/ |
+| app | [🔊](https://dict.youdao.com/dictvoice?audio=app&type=1)  /æp/ | [🔊](https://dict.youdao.com/dictvoice?audio=app&type=2)  /æp/ |  ❌ /eipi'pi/ |
+| archive | [🔊](https://dict.youdao.com/dictvoice?audio=archive&type=1)  /'ɑːkaɪv/ | [🔊](https://dict.youdao.com/dictvoice?audio=archive&type=2)  /'ɑːkaɪv/ |  ❌ /'ətʃɪv/ |
+| array | [🔊](https://dict.youdao.com/dictvoice?audio=array&type=1)  /ə'rei/ | [🔊](https://dict.youdao.com/dictvoice?audio=array&type=2)  /əˈreɪ/ |  ❌ /æ'rei/ |
+| ASCII | [🔊](https://dict.youdao.com/dictvoice?audio=ascii&type=1)  /'æski/ | [🔊](https://dict.youdao.com/dictvoice?audio=ascii&type=2)  /ˈæski/ |  ❌ /ɑːsk/ |
+| aspect | [🔊](https://dict.youdao.com/dictvoice?audio=aspect&type=1)  /'æspekt/ | [🔊](https://dict.youdao.com/dictvoice?audio=aspect&type=2)  /ˈæspekt/ |  ❌ /ə'spekt/ |
+| avatar | [🔊](https://dict.youdao.com/dictvoice?audio=avatar&type=1)  /'ævətɑː/ | [🔊](https://dict.youdao.com/dictvoice?audio=avatar&type=2)  /ˈævətɑːr/ |  ❌ /ə'vʌtɑ/ |
+| Azure | [🔊](https://dict.youdao.com/dictvoice?audio=azure&type=1)  /'æʒə/ | [🔊](https://dict.youdao.com/dictvoice?audio=azure&type=2)  /ˈæʒər/ |  ❌ /ˈæzʊʒə/ |
+| bind | [🔊](https://dict.youdao.com/dictvoice?audio=bind&type=1)  /baɪnd/ | [🔊](https://dict.youdao.com/dictvoice?audio=bind&type=2)  /baɪnd/ |  ❌ /bɪnd/ |
+| cache | [🔊](https://dict.youdao.com/dictvoice?audio=cache&type=1)  /kæʃ/ | [🔊](https://dict.youdao.com/dictvoice?audio=cache&type=2)  /kæʃ/ |  ❌ /kætʃ/ |
+| clang | [🔊](https://dict.youdao.com/dictvoice?audio=clang&type=1)  /klæŋ/ | [🔊](https://dict.youdao.com/dictvoice?audio=clang&type=2)  /klæŋ/ |  ❌ /sɪlæŋ/ |
+| daemon | [🔊](https://dict.youdao.com/dictvoice?audio=Daemon&type=1)  /'diːmən/ | [🔊](https://dict.youdao.com/dictvoice?audio=Daemon&type=2)  /ˈdiːmən/ |  ❌ /dæmən/ |
+| debt | [🔊](https://dict.youdao.com/dictvoice?audio=debt&type=1)  /det/ | [🔊](https://dict.youdao.com/dictvoice?audio=debt&type=2)  /det/ |  ❌ /de'bit/ |
+| deny | [🔊](https://dict.youdao.com/dictvoice?audio=deny&type=1)  /dɪ'naɪ/ | [🔊](https://dict.youdao.com/dictvoice?audio=deny&type=2)  /dɪˈnaɪ/ |  ❌ /'dæni/ |
+| deprecate | [🔊](https://dict.youdao.com/dictvoice?audio=deprecate&type=1) /ˈdeprəkeɪt/ | [🔊](https://dict.youdao.com/dictvoice?audio=deprecate&type=2) /ˈdeprəkeɪt/ |  |
+| deque | [🔊](https://dict.youdao.com/dictvoice?audio=deque&type=1)  /'dek/ | [🔊](https://dict.youdao.com/dictvoice?audio=deque&type=2)  /dɛk/ |  ❌ /di'kju/ |
+| digest | [🔊](https://dict.youdao.com/dictvoice?audio=digest&type=1)  n. /'dɑɪdʒɛst/ v. /dɑɪ'dʒɛst/ | [🔊](https://dict.youdao.com/dictvoice?audio=digest&type=2)  /daɪˈdʒest,dɪˈdʒest/ |  ❌ /'dɪgɛst/ |
 | Dijkstra | [🔊](https://upload.wikimedia.org/wikipedia/commons/8/85/Dijkstra.ogg)  Dutch:/ˈdɛikstra/ English:/ˈdaɪkstrə/ | [🔊](https://upload.wikimedia.org/wikipedia/commons/8/85/Dijkstra.ogg)    |   |
-| Django | [🔊](http://dict.youdao.com/dictvoice?audio=Django&type=1)  /ˈdʒæŋɡoʊ/ | [🔊](http://dict.youdao.com/dictvoice?audio=Django&type=2)  /ˈdʒæŋɡoʊ/ |  ❌ /diˈdʒæŋɡoʊ/ |
-| doc | [🔊](http://dict.youdao.com/dictvoice?audio=doc&type=1)  /dɒk/ | [🔊](http://dict.youdao.com/dictvoice?audio=doc&type=2)  /dɒk/ |  ❌ /daʊk/ |
-| epoch  | [🔊](http://dict.youdao.com/dictvoice?audio=epoch&type=1)  /ˈiːpɒk/ | [🔊](http://dict.youdao.com/dictvoice?audio=epoch&type=2)  /ˈepək/ |  ❌ /'ɛpətʃ/ |
-| execute | [🔊](http://dict.youdao.com/dictvoice?audio=execute&type=1) /ˈeksɪkjuːt/ | [🔊](http://dict.youdao.com/dictvoice?audio=execute&type=2) /ˈeksɪkjuːt/ |  |
-| executor | [🔊](http://dict.youdao.com/dictvoice?audio=executor&type=1) /ɪɡˈzekjətə(r)/ | [🔊](http://dict.youdao.com/dictvoice?audio=executor&type=2) /ɪɡˈzekjətər/ |  |
-| event | [🔊](http://dict.youdao.com/dictvoice?audio=event&type=1)  /ɪ'vent/ | [🔊](http://dict.youdao.com/dictvoice?audio=event&type=2)  /ɪˈvent/ |  ❌ /'ɪvənt/ |
-| facade | [🔊](http://dict.youdao.com/dictvoice?audio=facade&type=1)  /fə'sɑːd/ | [🔊](http://dict.youdao.com/dictvoice?audio=facade&type=2)  /fəˈsɑːd/ |  ❌ /'feikeid/ |
-| fedora | [🔊](http://dict.youdao.com/dictvoice?audio=fedora&type=1)  /fɪ'dɔːrə/ | [🔊](http://dict.youdao.com/dictvoice?audio=fedora&type=2)  /fɪˈdɔːrə/ |  ❌ /'fedərə/ |
-| format | [🔊](http://dict.youdao.com/dictvoice?audio=format&type=1)  /'fɔːmæt/ | [🔊](http://dict.youdao.com/dictvoice?audio=format&type=2)  /ˈfɔːrmæt/ |  ❌ /fɔ'mæt/ |
-| gauge | [🔊](http://dict.youdao.com/dictvoice?audio=gauge&type=1) /ɡeɪdʒ/ | [🔊](http://dict.youdao.com/dictvoice?audio=gauge&type=2) /ɡeɪdʒ/ |  ❌ /ɡɑudʒ/ |
-| Git | [🔊](http://dict.youdao.com/dictvoice?audio=git&type=1)  /ɡɪt/ | [🔊](http://dict.youdao.com/dictvoice?audio=git&type=2)  /ɡɪt/ |  ❌ /dʒɪt/ |
+| Django | [🔊](https://dict.youdao.com/dictvoice?audio=Django&type=1)  /ˈdʒæŋɡoʊ/ | [🔊](https://dict.youdao.com/dictvoice?audio=Django&type=2)  /ˈdʒæŋɡoʊ/ |  ❌ /diˈdʒæŋɡoʊ/ |
+| doc | [🔊](https://dict.youdao.com/dictvoice?audio=doc&type=1)  /dɒk/ | [🔊](https://dict.youdao.com/dictvoice?audio=doc&type=2)  /dɒk/ |  ❌ /daʊk/ |
+| epoch  | [🔊](https://dict.youdao.com/dictvoice?audio=epoch&type=1)  /ˈiːpɒk/ | [🔊](https://dict.youdao.com/dictvoice?audio=epoch&type=2)  /ˈepək/ |  ❌ /'ɛpətʃ/ |
+| execute | [🔊](https://dict.youdao.com/dictvoice?audio=execute&type=1) /ˈeksɪkjuːt/ | [🔊](https://dict.youdao.com/dictvoice?audio=execute&type=2) /ˈeksɪkjuːt/ |  |
+| executor | [🔊](https://dict.youdao.com/dictvoice?audio=executor&type=1) /ɪɡˈzekjətə(r)/ | [🔊](https://dict.youdao.com/dictvoice?audio=executor&type=2) /ɪɡˈzekjətər/ |  |
+| event | [🔊](https://dict.youdao.com/dictvoice?audio=event&type=1)  /ɪ'vent/ | [🔊](https://dict.youdao.com/dictvoice?audio=event&type=2)  /ɪˈvent/ |  ❌ /'ɪvənt/ |
+| facade | [🔊](https://dict.youdao.com/dictvoice?audio=facade&type=1)  /fə'sɑːd/ | [🔊](https://dict.youdao.com/dictvoice?audio=facade&type=2)  /fəˈsɑːd/ |  ❌ /'feikeid/ |
+| fedora | [🔊](https://dict.youdao.com/dictvoice?audio=fedora&type=1)  /fɪ'dɔːrə/ | [🔊](https://dict.youdao.com/dictvoice?audio=fedora&type=2)  /fɪˈdɔːrə/ |  ❌ /'fedərə/ |
+| format | [🔊](https://dict.youdao.com/dictvoice?audio=format&type=1)  /'fɔːmæt/ | [🔊](https://dict.youdao.com/dictvoice?audio=format&type=2)  /ˈfɔːrmæt/ |  ❌ /fɔ'mæt/ |
+| gauge | [🔊](https://dict.youdao.com/dictvoice?audio=gauge&type=1) /ɡeɪdʒ/ | [🔊](https://dict.youdao.com/dictvoice?audio=gauge&type=2) /ɡeɪdʒ/ |  ❌ /ɡɑudʒ/ |
+| Git | [🔊](https://dict.youdao.com/dictvoice?audio=git&type=1)  /ɡɪt/ | [🔊](https://dict.youdao.com/dictvoice?audio=git&type=2)  /ɡɪt/ |  ❌ /dʒɪt/ |
 | GNU | [🔊](https://upload.wikimedia.org/wikipedia/commons/2/24/En-gnu.ogg)  /gnu:/ | [🔊](https://upload.wikimedia.org/wikipedia/commons/2/24/En-gnu.ogg)  /nuː,njuː/ |  |
 | Grafana | [🔊](http://www.howtopronounce.cc/file/e204a97ed1e440c5ab15ea0117beb955.mp3)   /grəˈfɑːnˌɑː/ | [🔊](http://www.howtopronounce.cc/file/e204a97ed1e440c5ab15ea0117beb955.mp3 )   /grəˈfɑːnˌɑː/ |  |
-| GraphQL | [🔊](http://dict.youdao.com/dictvoice?audio=GraphQL&type=1)  /græf kju ɛl/ | [🔊](http://dict.youdao.com/dictvoice?audio=GraphQL&type=2)  /græf kju ɛl/ |  ❌ /dʒɪgræf kju ɛl/ |
-| GUI | [🔊](http://dict.youdao.com/dictvoice?audio={GUI}&type=1)  /ˈɡu:i/ | [🔊](http://dict.youdao.com/dictvoice?audio={GUI}&type=2)  /ˈɡu:i/ |  |
-| Haskell | [🔊](http://dict.youdao.com/dictvoice?audio=haskell&type=1)  /ˈhæskəl/ | [🔊](http://dict.youdao.com/dictvoice?audio=haskell&type=2)  /ˈhæskəl/ |  ❌ /hæˈskəl/ |
-| height | [🔊](http://dict.youdao.com/dictvoice?audio=height&type=1)  /haɪt/ | [🔊](http://dict.youdao.com/dictvoice?audio=height&type=2)  /haɪt/ |  ❌ /heɪt/ |
-| hidden | [🔊](http://dict.youdao.com/dictvoice?audio=hidden&type=1)  /'hɪdn/ | [🔊](http://dict.youdao.com/dictvoice?audio=hidden&type=2)  /ˈhɪdn/ |  ❌ /'haɪdn/ |
-| image | [🔊](http://dict.youdao.com/dictvoice?audio=image&type=1)  /'ɪmɪdʒ/ | [🔊](http://dict.youdao.com/dictvoice?audio=image&type=2)  /ˈɪmɪdʒ/ |  ❌ /ɪ'meɪdʒ/ |
-| implement | [🔊](http://dict.youdao.com/dictvoice?audio=implement&type=1)  /'ɪmplɪm(ə)nt/ | [🔊](http://dict.youdao.com/dictvoice?audio=implement&type=2)  /ˈɪmplɪmənt/ /ˈɪmpləˌment/ |  ❌ /ɪm'plem(ə)nt/ |
-| integer | [🔊](http://dict.youdao.com/dictvoice?audio=integer&type=1)  /'ɪntɪdʒə/ | [🔊](http://dict.youdao.com/dictvoice?audio=integer&type=2)  /ˈɪntɪdʒər/ |  ❌ /ˈɪntaɪgə/ |
-| issue | [🔊](http://dict.youdao.com/dictvoice?audio=issue&type=1)  /'ɪʃuː/ | [🔊](http://dict.youdao.com/dictvoice?audio=issue&type=2)  /ˈɪʃuː/ |  ❌ /ˈaɪʃuː/ |
-| Java | [🔊](http://dict.youdao.com/dictvoice?audio=java&type=1)  /'dʒɑːvə/ | [🔊](http://dict.youdao.com/dictvoice?audio=java&type=2)  /ˈdʒɑːvə/ |  ❌ /'dʒɑːvɑː/ |
-| jpg| [🔊](http://dict.youdao.com/dictvoice?audio=JPEG&type=1)  /'dʒeɪpeɡ/ | [🔊](http://dict.youdao.com/dictvoice?audio=JPEG&type=2)  /'dʒeɪpeɡ/ |  ❌ /ˈdʒeɪˈpi:ˈdʒiː/ |
-| key | [🔊](http://dict.youdao.com/dictvoice?audio=key&type=1)  /kiː/ | [🔊](http://dict.youdao.com/dictvoice?audio=key&type=2)  /kiː/ |  ❌ /kei/ |
-| Kubernetes* | [🔊](http://dict.youdao.com/dictvoice?audio=Kubernetes&type=2)  /kubз'netɪs/ | [🔊](http://dict.youdao.com/dictvoice?audio=Kubernetes&type=2)  /kuːbə˞'netiz/ |   |
-| lambda | [🔊](http://dict.youdao.com/dictvoice?audio=lambda&type=1)  /ˈlæmdə/ | [🔊](http://dict.youdao.com/dictvoice?audio=lambda&type=2)  /ˈlæmdə/ |  ❌ /ˈlɒŋmdɑ/ |
-| linear | [🔊](http://dict.youdao.com/dictvoice?audio=linear&type=1)  /'lɪnɪə/ | [🔊](http://dict.youdao.com/dictvoice?audio=linear&type=2)  /ˈlɪniər/ |  ❌ /'laɪə/ |
-| Linux | [🔊](http://dict.youdao.com/dictvoice?audio=linux&type=1)  /'lɪnəks/ | [🔊](http://dict.youdao.com/dictvoice?audio=linux&type=2)  /ˈlaɪnəks/ /ˈlɪnəks/ |  ❌ /ˈlɪnʌks/ /ˈlɪnjuːks/ |
-| locale | [🔊](http://dict.youdao.com/dictvoice?audio=locale&type=1)  /ləʊ'kɑːl/ | [🔊](http://dict.youdao.com/dictvoice?audio=locale&type=2)  /loʊˈkæl/ |  ❌ /ˈloʊk(ə)l/ |
-| Lucene | [🔊](http://dict.youdao.com/dictvoice?audio=lucene&type=1)  /lu'siːn/ | [🔊](http://dict.youdao.com/dictvoice?audio=lucene&type=2)  /lu'siːn/ |  ❌ /'lu:sən/ |
-| main | [🔊](http://dict.youdao.com/dictvoice?audio=main&type=1)  /meɪn/ | [🔊](http://dict.youdao.com/dictvoice?audio=main&type=2)  /meɪn/ |  ❌ /mɪn/ |
-| margin | [🔊](http://dict.youdao.com/dictvoice?audio=margin&type=1)  /'mɑːdʒɪn/ | [🔊](http://dict.youdao.com/dictvoice?audio=margin&type=2)  /ˈmɑːrdʒɪn/ |  ❌ /'mʌgɪn/ |
-| matrix | [🔊](http://dict.youdao.com/dictvoice?audio=matrix&type=1)  /ˈmeɪtrɪks/ | [🔊](http://dict.youdao.com/dictvoice?audio=matrix&type=2)  /ˈmeɪtrɪks/ |  ❌ /ˈmɑ:trɪks/ |
-| maven | [🔊](http://dict.youdao.com/dictvoice?audio=maven&type=1)  /'meɪvn/ | [🔊](http://dict.youdao.com/dictvoice?audio=maven&type=2)  /ˈmeɪvn/ |  ❌ /'maːvn/ |
-| Microsoft | [🔊](http://dict.youdao.com/dictvoice?audio=Microsoft&type=1)  /'maikrəusɔft/ | [🔊](http://dict.youdao.com/dictvoice?audio=Microsoft&type=2)  /ˈmaɪkrəsɔːft/ |  ❌ /'mikrəusɔft/ |
-| miscellaneous | [🔊](http://dict.youdao.com/dictvoice?audio=miscellaneous&type=1) /ˌmɪsəˈleɪniəs/ | [🔊](http://dict.youdao.com/dictvoice?audio=miscellaneous&type=2) /ˌmɪsəˈleɪniəs/ |  |
-| module | [🔊](http://dict.youdao.com/dictvoice?audio=module&type=1)  /'mɒdjuːl/ | [🔊](http://dict.youdao.com/dictvoice?audio=module&type=2)  /ˈmɑːdʒuːl/ |  ❌ /'məʊdl/ |
+| GraphQL | [🔊](https://dict.youdao.com/dictvoice?audio=GraphQL&type=1)  /græf kju ɛl/ | [🔊](https://dict.youdao.com/dictvoice?audio=GraphQL&type=2)  /græf kju ɛl/ |  ❌ /dʒɪgræf kju ɛl/ |
+| GUI | [🔊](https://dict.youdao.com/dictvoice?audio={GUI}&type=1)  /ˈɡu:i/ | [🔊](https://dict.youdao.com/dictvoice?audio={GUI}&type=2)  /ˈɡu:i/ |  |
+| Haskell | [🔊](https://dict.youdao.com/dictvoice?audio=haskell&type=1)  /ˈhæskəl/ | [🔊](https://dict.youdao.com/dictvoice?audio=haskell&type=2)  /ˈhæskəl/ |  ❌ /hæˈskəl/ |
+| height | [🔊](https://dict.youdao.com/dictvoice?audio=height&type=1)  /haɪt/ | [🔊](https://dict.youdao.com/dictvoice?audio=height&type=2)  /haɪt/ |  ❌ /heɪt/ |
+| hidden | [🔊](https://dict.youdao.com/dictvoice?audio=hidden&type=1)  /'hɪdn/ | [🔊](https://dict.youdao.com/dictvoice?audio=hidden&type=2)  /ˈhɪdn/ |  ❌ /'haɪdn/ |
+| image | [🔊](https://dict.youdao.com/dictvoice?audio=image&type=1)  /'ɪmɪdʒ/ | [🔊](https://dict.youdao.com/dictvoice?audio=image&type=2)  /ˈɪmɪdʒ/ |  ❌ /ɪ'meɪdʒ/ |
+| implement | [🔊](https://dict.youdao.com/dictvoice?audio=implement&type=1)  /'ɪmplɪm(ə)nt/ | [🔊](https://dict.youdao.com/dictvoice?audio=implement&type=2)  /ˈɪmplɪmənt/ /ˈɪmpləˌment/ |  ❌ /ɪm'plem(ə)nt/ |
+| integer | [🔊](https://dict.youdao.com/dictvoice?audio=integer&type=1)  /'ɪntɪdʒə/ | [🔊](https://dict.youdao.com/dictvoice?audio=integer&type=2)  /ˈɪntɪdʒər/ |  ❌ /ˈɪntaɪgə/ |
+| issue | [🔊](https://dict.youdao.com/dictvoice?audio=issue&type=1)  /'ɪʃuː/ | [🔊](https://dict.youdao.com/dictvoice?audio=issue&type=2)  /ˈɪʃuː/ |  ❌ /ˈaɪʃuː/ |
+| Java | [🔊](https://dict.youdao.com/dictvoice?audio=java&type=1)  /'dʒɑːvə/ | [🔊](https://dict.youdao.com/dictvoice?audio=java&type=2)  /ˈdʒɑːvə/ |  ❌ /'dʒɑːvɑː/ |
+| jpg| [🔊](https://dict.youdao.com/dictvoice?audio=JPEG&type=1)  /'dʒeɪpeɡ/ | [🔊](https://dict.youdao.com/dictvoice?audio=JPEG&type=2)  /'dʒeɪpeɡ/ |  ❌ /ˈdʒeɪˈpi:ˈdʒiː/ |
+| key | [🔊](https://dict.youdao.com/dictvoice?audio=key&type=1)  /kiː/ | [🔊](https://dict.youdao.com/dictvoice?audio=key&type=2)  /kiː/ |  ❌ /kei/ |
+| Kubernetes* | [🔊](https://dict.youdao.com/dictvoice?audio=Kubernetes&type=2)  /kubз'netɪs/ | [🔊](https://dict.youdao.com/dictvoice?audio=Kubernetes&type=2)  /kuːbə˞'netiz/ |   |
+| lambda | [🔊](https://dict.youdao.com/dictvoice?audio=lambda&type=1)  /ˈlæmdə/ | [🔊](https://dict.youdao.com/dictvoice?audio=lambda&type=2)  /ˈlæmdə/ |  ❌ /ˈlɒŋmdɑ/ |
+| linear | [🔊](https://dict.youdao.com/dictvoice?audio=linear&type=1)  /'lɪnɪə/ | [🔊](https://dict.youdao.com/dictvoice?audio=linear&type=2)  /ˈlɪniər/ |  ❌ /'laɪə/ |
+| Linux | [🔊](https://dict.youdao.com/dictvoice?audio=linux&type=1)  /'lɪnəks/ | [🔊](https://dict.youdao.com/dictvoice?audio=linux&type=2)  /ˈlaɪnəks/ /ˈlɪnəks/ |  ❌ /ˈlɪnʌks/ /ˈlɪnjuːks/ |
+| locale | [🔊](https://dict.youdao.com/dictvoice?audio=locale&type=1)  /ləʊ'kɑːl/ | [🔊](https://dict.youdao.com/dictvoice?audio=locale&type=2)  /loʊˈkæl/ |  ❌ /ˈloʊk(ə)l/ |
+| Lucene | [🔊](https://dict.youdao.com/dictvoice?audio=lucene&type=1)  /lu'siːn/ | [🔊](https://dict.youdao.com/dictvoice?audio=lucene&type=2)  /lu'siːn/ |  ❌ /'lu:sən/ |
+| main | [🔊](https://dict.youdao.com/dictvoice?audio=main&type=1)  /meɪn/ | [🔊](https://dict.youdao.com/dictvoice?audio=main&type=2)  /meɪn/ |  ❌ /mɪn/ |
+| margin | [🔊](https://dict.youdao.com/dictvoice?audio=margin&type=1)  /'mɑːdʒɪn/ | [🔊](https://dict.youdao.com/dictvoice?audio=margin&type=2)  /ˈmɑːrdʒɪn/ |  ❌ /'mʌgɪn/ |
+| matrix | [🔊](https://dict.youdao.com/dictvoice?audio=matrix&type=1)  /ˈmeɪtrɪks/ | [🔊](https://dict.youdao.com/dictvoice?audio=matrix&type=2)  /ˈmeɪtrɪks/ |  ❌ /ˈmɑ:trɪks/ |
+| maven | [🔊](https://dict.youdao.com/dictvoice?audio=maven&type=1)  /'meɪvn/ | [🔊](https://dict.youdao.com/dictvoice?audio=maven&type=2)  /ˈmeɪvn/ |  ❌ /'maːvn/ |
+| Microsoft | [🔊](https://dict.youdao.com/dictvoice?audio=Microsoft&type=1)  /'maikrəusɔft/ | [🔊](https://dict.youdao.com/dictvoice?audio=Microsoft&type=2)  /ˈmaɪkrəsɔːft/ |  ❌ /'mikrəusɔft/ |
+| miscellaneous | [🔊](https://dict.youdao.com/dictvoice?audio=miscellaneous&type=1) /ˌmɪsəˈleɪniəs/ | [🔊](https://dict.youdao.com/dictvoice?audio=miscellaneous&type=2) /ˌmɪsəˈleɪniəs/ |  |
+| module | [🔊](https://dict.youdao.com/dictvoice?audio=module&type=1)  /'mɒdjuːl/ | [🔊](https://dict.youdao.com/dictvoice?audio=module&type=2)  /ˈmɑːdʒuːl/ |  ❌ /'məʊdl/ |
 | nginx |      Engine X |    Engine X  |  |
-| null | [🔊](http://dict.youdao.com/dictvoice?audio=null&type=1)  /nʌl/ | [🔊](http://dict.youdao.com/dictvoice?audio=null&type=2)  /nʌl/ |  ❌ /naʊ/ |
-| obsolete | [🔊](http://dict.youdao.com/dictvoice?audio=obsolete&type=1) /ˈɒbsəliːt/ | [🔊](http://dict.youdao.com/dictvoice?audio=obsolete&type=2) /ˌɑːbsəˈliːt/ |  |
+| null | [🔊](https://dict.youdao.com/dictvoice?audio=null&type=1)  /nʌl/ | [🔊](https://dict.youdao.com/dictvoice?audio=null&type=2)  /nʌl/ |  ❌ /naʊ/ |
+| obsolete | [🔊](https://dict.youdao.com/dictvoice?audio=obsolete&type=1) /ˈɒbsəliːt/ | [🔊](https://dict.youdao.com/dictvoice?audio=obsolete&type=2) /ˌɑːbsəˈliːt/ |  |
 | OS X |    OS ten |    OS ten |  ❌ /ɔs eks/ |
-| phantom | [🔊](http://dict.youdao.com/dictvoice?audio=phantom&type=1)  /'fæntəm/ | [🔊](http://dict.youdao.com/dictvoice?audio=phantom&type=2)  /ˈfæntəm/ |  ❌ /'pæntəm/ |
-| parameter | [🔊](http://dict.youdao.com/dictvoice?audio=parameter&type=1)  /pə'ræmɪtə/ | [🔊](http://dict.youdao.com/dictvoice?audio=parameter&type=2)  /pəˈræmɪtər/ |  ❌ /'pærəmɪtə/ |
-| privilege | [🔊](http://dict.youdao.com/dictvoice?audio=privilege&type=1)  /'prɪvəlɪdʒ/ | [🔊](http://dict.youdao.com/dictvoice?audio=privilege&type=2)  /ˈprɪvəlɪdʒ/ |  ❌ /'prɪvɪlɪdʒ/ |
-| Prometheus | [🔊](http://dict.youdao.com/dictvoice?audio=prometheus&type=1)  /prə-ˈmē-thē-əs/ | [🔊](http://dict.youdao.com/dictvoice?audio=prometheus&type=2)  /pro'miθɪəs/ |   |
-| putty | [🔊](http://dict.youdao.com/dictvoice?audio=putty&type=1)  /ˈpʌti/ | [🔊](http://dict.youdao.com/dictvoice?audio=putty&type=2)  /ˈpʌti/ |  ❌ /ˈpuːti/ |
-| Qt | [🔊](http://dict.youdao.com/dictvoice?audio=cute&type=1)  /kjuːt/ | [🔊](http://dict.youdao.com/dictvoice?audio=cute&type=2)  /kjuːt/ |  |
-| query | [🔊](http://dict.youdao.com/dictvoice?audio=query&type=1)  /'kwɪəri/ | [🔊](http://dict.youdao.com/dictvoice?audio=query&type=2)  /ˈkwɪri/ |  ❌ /'kwaɪri/ |
-| Realm | [🔊](http://dict.youdao.com/dictvoice?audio=realm&type=1)  /relm/ | [🔊](http://dict.youdao.com/dictvoice?audio=realm&type=2)  /relm/ |  ❌ /riəlm/ |
-| reconcile | [🔊](http://dict.youdao.com/dictvoice?audio=reconcile&type=1) /ˈrekənsaɪl/ | [🔊](http://dict.youdao.com/dictvoice?audio=reconcile&type=2) /ˈrekənsaɪl/ |  |
-| Redux | [🔊](http://dict.youdao.com/dictvoice?audio=redux&type=1)  /ri'dʌks/ | [🔊](http://dict.youdao.com/dictvoice?audio=redux&type=2)  /ri'dʌks/ |  ❌ /'ridju:ks/ |
-| resume | [🔊](http://dict.youdao.com/dictvoice?audio=resume&type=1)   /rɪ'zju:m/ | [🔊](http://dict.youdao.com/dictvoice?audio=resume&type=2)  /rɪˈzuːm/ |  ❌  /rɪ'sju:m/ |
-| resolved | [🔊](http://dict.youdao.com/dictvoice?audio=resolved&type=1)  /rɪ'zɒlvd/ | [🔊](http://dict.youdao.com/dictvoice?audio=resolved&type=2)  /rɪˈzɑːlvd/ |  ❌ /rɪ'səʊvd/ |
-| resort | [🔊](http://dict.youdao.com/dictvoice?audio=resort&type=1)  /rɪˈzɔ:t/ | [🔊](http://dict.youdao.com/dictvoice?audio=resort&type=2)  /rɪˈzɔːrt/ |  ❌ /rɪˈsɔ:t/ |
-| retina | [🔊](http://dict.youdao.com/dictvoice?audio=retina&type=1)  /'retɪnə/ | [🔊](http://dict.youdao.com/dictvoice?audio=retina&type=2)  /ˈretɪnə/ |  ❌ /ri'tina/ |
-| route | [🔊](http://dict.youdao.com/dictvoice?audio=route&type=1)  /ruːt/ | [🔊](http://dict.youdao.com/dictvoice?audio=route&type=2)  /ruːt,raʊt/ |  ❌ /rəʊt/ |
-| San Jose | [🔊](http://dict.youdao.com/dictvoice?audio=san%20jose&type=1)  /sænhəu'zei/ | [🔊](http://dict.youdao.com/dictvoice?audio=san%20jose&type=2)  /sænhəu'zei/ |  ❌ /sæn'ju:s/ |
-| safari | [🔊](http://dict.youdao.com/dictvoice?audio=safari&type=1)  /sə'fɑːrɪ/ | [🔊](http://dict.youdao.com/dictvoice?audio=safari&type=2)  /səˈfɑːri/ |  ❌ /sæfərɪ/ |
-| scheme | [🔊](http://dict.youdao.com/dictvoice?audio=scheme&type=1)  /skiːm/ | [🔊](http://dict.youdao.com/dictvoice?audio=scheme&type=2)  /skiːm/ |  ❌ /s'kæmə/ |
-| scala | [🔊](http://dict.youdao.com/dictvoice?audio=scala&type=1)  /ˈskɑːlɑ/ | [🔊](http://dict.youdao.com/dictvoice?audio=scala&type=2)  /ˈskɑːlɑ/ |  ❌ /ˈskæːlɑ/ |
-| segue | [🔊](http://dict.youdao.com/dictvoice?audio=segue&type=1)  /'sɛɡwe/ | [🔊](http://dict.youdao.com/dictvoice?audio=segue&type=2)  /ˈseɡweɪ/ |  ❌ /se'dʒ/ |
+| phantom | [🔊](https://dict.youdao.com/dictvoice?audio=phantom&type=1)  /'fæntəm/ | [🔊](https://dict.youdao.com/dictvoice?audio=phantom&type=2)  /ˈfæntəm/ |  ❌ /'pæntəm/ |
+| parameter | [🔊](https://dict.youdao.com/dictvoice?audio=parameter&type=1)  /pə'ræmɪtə/ | [🔊](https://dict.youdao.com/dictvoice?audio=parameter&type=2)  /pəˈræmɪtər/ |  ❌ /'pærəmɪtə/ |
+| privilege | [🔊](https://dict.youdao.com/dictvoice?audio=privilege&type=1)  /'prɪvəlɪdʒ/ | [🔊](https://dict.youdao.com/dictvoice?audio=privilege&type=2)  /ˈprɪvəlɪdʒ/ |  ❌ /'prɪvɪlɪdʒ/ |
+| Prometheus | [🔊](https://dict.youdao.com/dictvoice?audio=prometheus&type=1)  /prə-ˈmē-thē-əs/ | [🔊](https://dict.youdao.com/dictvoice?audio=prometheus&type=2)  /pro'miθɪəs/ |   |
+| putty | [🔊](https://dict.youdao.com/dictvoice?audio=putty&type=1)  /ˈpʌti/ | [🔊](https://dict.youdao.com/dictvoice?audio=putty&type=2)  /ˈpʌti/ |  ❌ /ˈpuːti/ |
+| Qt | [🔊](https://dict.youdao.com/dictvoice?audio=cute&type=1)  /kjuːt/ | [🔊](https://dict.youdao.com/dictvoice?audio=cute&type=2)  /kjuːt/ |  |
+| query | [🔊](https://dict.youdao.com/dictvoice?audio=query&type=1)  /'kwɪəri/ | [🔊](https://dict.youdao.com/dictvoice?audio=query&type=2)  /ˈkwɪri/ |  ❌ /'kwaɪri/ |
+| Realm | [🔊](https://dict.youdao.com/dictvoice?audio=realm&type=1)  /relm/ | [🔊](https://dict.youdao.com/dictvoice?audio=realm&type=2)  /relm/ |  ❌ /riəlm/ |
+| reconcile | [🔊](https://dict.youdao.com/dictvoice?audio=reconcile&type=1) /ˈrekənsaɪl/ | [🔊](https://dict.youdao.com/dictvoice?audio=reconcile&type=2) /ˈrekənsaɪl/ |  |
+| Redux | [🔊](https://dict.youdao.com/dictvoice?audio=redux&type=1)  /ri'dʌks/ | [🔊](https://dict.youdao.com/dictvoice?audio=redux&type=2)  /ri'dʌks/ |  ❌ /'ridju:ks/ |
+| resume | [🔊](https://dict.youdao.com/dictvoice?audio=resume&type=1)   /rɪ'zju:m/ | [🔊](https://dict.youdao.com/dictvoice?audio=resume&type=2)  /rɪˈzuːm/ |  ❌  /rɪ'sju:m/ |
+| resolved | [🔊](https://dict.youdao.com/dictvoice?audio=resolved&type=1)  /rɪ'zɒlvd/ | [🔊](https://dict.youdao.com/dictvoice?audio=resolved&type=2)  /rɪˈzɑːlvd/ |  ❌ /rɪ'səʊvd/ |
+| resort | [🔊](https://dict.youdao.com/dictvoice?audio=resort&type=1)  /rɪˈzɔ:t/ | [🔊](https://dict.youdao.com/dictvoice?audio=resort&type=2)  /rɪˈzɔːrt/ |  ❌ /rɪˈsɔ:t/ |
+| retina | [🔊](https://dict.youdao.com/dictvoice?audio=retina&type=1)  /'retɪnə/ | [🔊](https://dict.youdao.com/dictvoice?audio=retina&type=2)  /ˈretɪnə/ |  ❌ /ri'tina/ |
+| route | [🔊](https://dict.youdao.com/dictvoice?audio=route&type=1)  /ruːt/ | [🔊](https://dict.youdao.com/dictvoice?audio=route&type=2)  /ruːt,raʊt/ |  ❌ /rəʊt/ |
+| San Jose | [🔊](https://dict.youdao.com/dictvoice?audio=san%20jose&type=1)  /sænhəu'zei/ | [🔊](https://dict.youdao.com/dictvoice?audio=san%20jose&type=2)  /sænhəu'zei/ |  ❌ /sæn'ju:s/ |
+| safari | [🔊](https://dict.youdao.com/dictvoice?audio=safari&type=1)  /sə'fɑːrɪ/ | [🔊](https://dict.youdao.com/dictvoice?audio=safari&type=2)  /səˈfɑːri/ |  ❌ /sæfərɪ/ |
+| scheme | [🔊](https://dict.youdao.com/dictvoice?audio=scheme&type=1)  /skiːm/ | [🔊](https://dict.youdao.com/dictvoice?audio=scheme&type=2)  /skiːm/ |  ❌ /s'kæmə/ |
+| scala | [🔊](https://dict.youdao.com/dictvoice?audio=scala&type=1)  /ˈskɑːlɑ/ | [🔊](https://dict.youdao.com/dictvoice?audio=scala&type=2)  /ˈskɑːlɑ/ |  ❌ /ˈskæːlɑ/ |
+| segue | [🔊](https://dict.youdao.com/dictvoice?audio=segue&type=1)  /'sɛɡwe/ | [🔊](https://dict.youdao.com/dictvoice?audio=segue&type=2)  /ˈseɡweɪ/ |  ❌ /se'dʒ/ |
 | SQL | /ˈsiːkwəl/ /ˈesˈkjuːˈel/ | /ˈsiːkwəl/ /ˈesˈkjuːˈel/ |  |
 | sudo | /'suːduː/ | /'suːduː/ |  |
-| suite | [🔊](http://dict.youdao.com/dictvoice?audio=suite&type=1)  /swiːt/ | [🔊](http://dict.youdao.com/dictvoice?audio=suite&type=2)  /swiːt/ |  ❌ /sjuːt/ |
-| thymeleaf | [🔊](http://dict.youdao.com/dictvoice?audio=thymeleaf&type=1)  /ˈtaɪmˌlɪːf/ | [🔊](http://dict.youdao.com/dictvoice?audio=thymeleaf&type=2)  /ˈtaɪmˌlɪːf/ |  ❌ /θiːmɪlɪːf/ |
-| tuple | [🔊](http://dict.youdao.com/dictvoice?audio=tuple&type=1) /tjʊpəl/ | [🔊](http://dict.youdao.com/dictvoice?audio=tuple&type=2) /tuːpəl/ |  |
-| typical | [🔊](http://dict.youdao.com/dictvoice?audio=typical&type=1)  /'tɪpɪkl/ | [🔊](http://dict.youdao.com/dictvoice?audio=typical&type=2)  /ˈtɪpɪkl/ |  ❌ /'taɪpɪkəl/ |
+| suite | [🔊](https://dict.youdao.com/dictvoice?audio=suite&type=1)  /swiːt/ | [🔊](https://dict.youdao.com/dictvoice?audio=suite&type=2)  /swiːt/ |  ❌ /sjuːt/ |
+| thymeleaf | [🔊](https://dict.youdao.com/dictvoice?audio=thymeleaf&type=1)  /ˈtaɪmˌlɪːf/ | [🔊](https://dict.youdao.com/dictvoice?audio=thymeleaf&type=2)  /ˈtaɪmˌlɪːf/ |  ❌ /θiːmɪlɪːf/ |
+| tuple | [🔊](https://dict.youdao.com/dictvoice?audio=tuple&type=1) /tjʊpəl/ | [🔊](https://dict.youdao.com/dictvoice?audio=tuple&type=2) /tuːpəl/ |  |
+| typical | [🔊](https://dict.youdao.com/dictvoice?audio=typical&type=1)  /'tɪpɪkl/ | [🔊](https://dict.youdao.com/dictvoice?audio=typical&type=2)  /ˈtɪpɪkl/ |  ❌ /'taɪpɪkəl/ |
 | Ubuntu | [🔊](http://upload.wikimedia.org/wikipedia/commons/b/b5/En-Ubuntu_pronunciation.oga)  /ʊ'bʊntʊ/ | [🔊](http://upload.wikimedia.org/wikipedia/commons/b/b5/En-Ubuntu_pronunciation.oga)  /ʊ'bʊntʊ/ |  ❌ /juː'bʊntʊ/ |
-| Vagrant | [🔊](http://dict.youdao.com/dictvoice?audio=Vagrant&type=1) /ˈveɪɡrənt/ | [🔊](http://dict.youdao.com/dictvoice?audio=Vagrant&type=2) /ˈveɪɡrənt/ | /ˈvagɹent/ |
-| variable | [🔊](http://dict.youdao.com/dictvoice?audio=variable&type=1)  /'veəriəbl/ | [🔊](http://dict.youdao.com/dictvoice?audio=variable&type=2)  /ˈveriəbl,ˈværiəbl/ | ❌ /və'raiəbl/ |
-| verbose | [🔊](http://dict.youdao.com/dictvoice?audio=verbose&type=1)  /vɜːˈbəʊs/ | [🔊](http://dict.youdao.com/dictvoice?audio=verbose&type=2)  /vɜːrˈboʊs/ |  ❌ /'vɜːrboʊs/ |
-| vue | [🔊](http://dict.youdao.com/dictvoice?audio=vue&type=1)  /v'ju:/ | [🔊](http://dict.youdao.com/dictvoice?audio=vue&type=2)  /v'ju:/ |  ❌ /v'ju:i/ |
-| width | [🔊](http://dict.youdao.com/dictvoice?audio=width&type=1)  /wɪdθ/ | [🔊](http://dict.youdao.com/dictvoice?audio=width&type=2)  /wɪdθ,wɪtθ/ |  ❌ /waɪdθ/ |
-| YouTube | [🔊](http://dict.youdao.com/dictvoice?audio=youtube&type=1)  /'juː'tjuːb/ | [🔊](http://dict.youdao.com/dictvoice?audio=youtube&type=2)  /'juː'tjuːb/ |  ❌ /'juː'tʊbɪ/ |
+| Vagrant | [🔊](https://dict.youdao.com/dictvoice?audio=Vagrant&type=1) /ˈveɪɡrənt/ | [🔊](https://dict.youdao.com/dictvoice?audio=Vagrant&type=2) /ˈveɪɡrənt/ | /ˈvagɹent/ |
+| variable | [🔊](https://dict.youdao.com/dictvoice?audio=variable&type=1)  /'veəriəbl/ | [🔊](https://dict.youdao.com/dictvoice?audio=variable&type=2)  /ˈveriəbl,ˈværiəbl/ | ❌ /və'raiəbl/ |
+| verbose | [🔊](https://dict.youdao.com/dictvoice?audio=verbose&type=1)  /vɜːˈbəʊs/ | [🔊](https://dict.youdao.com/dictvoice?audio=verbose&type=2)  /vɜːrˈboʊs/ |  ❌ /'vɜːrboʊs/ |
+| vue | [🔊](https://dict.youdao.com/dictvoice?audio=vue&type=1)  /v'ju:/ | [🔊](https://dict.youdao.com/dictvoice?audio=vue&type=2)  /v'ju:/ |  ❌ /v'ju:i/ |
+| width | [🔊](https://dict.youdao.com/dictvoice?audio=width&type=1)  /wɪdθ/ | [🔊](https://dict.youdao.com/dictvoice?audio=width&type=2)  /wɪdθ,wɪtθ/ |  ❌ /waɪdθ/ |
+| YouTube | [🔊](https://dict.youdao.com/dictvoice?audio=youtube&type=1)  /'juː'tjuːb/ | [🔊](https://dict.youdao.com/dictvoice?audio=youtube&type=2)  /'juː'tjuːb/ |  ❌ /'juː'tʊbɪ/ |
 
 ### 附注
 * 当使用简名 ‘Kube’ 称呼 ‘Kubernetes’ 时, 发音则与 ‘cube’(/kjuːb/) 一致

--- a/tools/addword.py
+++ b/tools/addword.py
@@ -25,8 +25,8 @@ def get_pronunciations(word):
     """Return the word's pronouciation URLs and phonetic transcriptions
        from youdao.com if available"""
     word = word.strip()
-    word_url = "http://dict.youdao.com/w/en/"+word
-    pron_url = "http://dict.youdao.com/dictvoice?audio="+word+"&"
+    word_url = "https://dict.youdao.com/w/en/"+word
+    pron_url = "https://dict.youdao.com/dictvoice?audio="+word+"&"
     britsh_en = [" ", " "]
     american_en = [" "," "]
     try:


### PR DESCRIPTION
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
