### PR TITLE
Java: /'dʒɑːvɑː/ is not wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 | implement | [🔊](https://dict.youdao.com/dictvoice?audio=implement&type=1)  /'ɪmplɪm(ə)nt/ | [🔊](https://dict.youdao.com/dictvoice?audio=implement&type=2)  /ˈɪmplɪmənt/ /ˈɪmpləˌment/ |  ❌ /ɪm'plem(ə)nt/ |
 | integer | [🔊](https://dict.youdao.com/dictvoice?audio=integer&type=1)  /'ɪntɪdʒə/ | [🔊](https://dict.youdao.com/dictvoice?audio=integer&type=2)  /ˈɪntɪdʒər/ |  ❌ /ˈɪntaɪgə/ |
 | issue | [🔊](https://dict.youdao.com/dictvoice?audio=issue&type=1)  /'ɪʃuː/ | [🔊](https://dict.youdao.com/dictvoice?audio=issue&type=2)  /ˈɪʃuː/ |  ❌ /ˈaɪʃuː/ |
-| Java | [🔊](https://dict.youdao.com/dictvoice?audio=java&type=1)  /'dʒɑːvə/ | [🔊](https://dict.youdao.com/dictvoice?audio=java&type=2)  /ˈdʒɑːvə/ |  ❌ /'dʒɑːvɑː/ |
+| Java | [🔊](https://dict.youdao.com/dictvoice?audio=java&type=1)  /'dʒɑːvə/ | [🔊](https://dict.youdao.com/dictvoice?audio=java&type=2)  /ˈdʒɑːvə/ |  |
 | jpg| [🔊](https://dict.youdao.com/dictvoice?audio=JPEG&type=1)  /'dʒeɪpeɡ/ | [🔊](https://dict.youdao.com/dictvoice?audio=JPEG&type=2)  /'dʒeɪpeɡ/ |  ❌ /ˈdʒeɪˈpi:ˈdʒiː/ |
 | key | [🔊](https://dict.youdao.com/dictvoice?audio=key&type=1)  /kiː/ | [🔊](https://dict.youdao.com/dictvoice?audio=key&type=2)  /kiː/ |  ❌ /kei/ |
 | Kubernetes* | [🔊](https://dict.youdao.com/dictvoice?audio=Kubernetes&type=2)  /kubз'netɪs/ | [🔊](https://dict.youdao.com/dictvoice?audio=Kubernetes&type=2)  /kuːbə˞'netiz/ |   |


### PR DESCRIPTION
per https://github.com/shimohq/chinese-programmer-wrong-pronunciation/pull/65#issuecomment-736089904

<!--
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
-->
