### PR TITLE
添加一个可以连读的网站

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 1. 真人发音 https://www.bilibili.com/video/bv1nv411i7z3 (by @hailintao)
 1. 简洁的单词列表，正确读音不用再打开新网页 https://cpwp.netlify.app/ (by @antfu7)
 1. 国际音标严式记音（纽约音）https://github.com/b1f6c1c4/programming-pronunciations-en_US (by @b1f6c1c4)
+2. 单词连读 https://corrector.justsong.cn/ (by [@songquanpeng](https://github.com/songquanpeng/pronunciation-corrector))
 
 
 ### 说明


### PR DESCRIPTION
<!--
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
-->
你好，我基于本词库和其他词库做了一个可以自动连读的网站：https://corrector.justsong.cn/ 

自我感觉还是有点帮助的，请问可以放到「其他相关链接」中吗？