### PR TITLE
解决mac系统chrome浏览器上，点击音频图标无反应；单词 ubuntu 启用https

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@
 | thymeleaf | [🔊](https://dict.youdao.com/dictvoice?audio=thymeleaf&type=1)  /ˈtaɪmˌlɪːf/ | [🔊](https://dict.youdao.com/dictvoice?audio=thymeleaf&type=2)  /ˈtaɪmˌlɪːf/ |  ❌ /θiːmɪlɪːf/ |
 | tuple | [🔊](https://dict.youdao.com/dictvoice?audio=tuple&type=1) /tjʊpəl/ | [🔊](https://dict.youdao.com/dictvoice?audio=tuple&type=2) /tuːpəl/ |  |
 | typical | [🔊](https://dict.youdao.com/dictvoice?audio=typical&type=1)  /'tɪpɪkl/ | [🔊](https://dict.youdao.com/dictvoice?audio=typical&type=2)  /ˈtɪpɪkl/ |  ❌ /'taɪpɪkəl/ |
-| Ubuntu | [🔊](http://upload.wikimedia.org/wikipedia/commons/b/b5/En-Ubuntu_pronunciation.oga)  /ʊ'bʊntʊ/ | [🔊](http://upload.wikimedia.org/wikipedia/commons/b/b5/En-Ubuntu_pronunciation.oga)  /ʊ'bʊntʊ/ |  ❌ /juː'bʊntʊ/ |
+| Ubuntu | [🔊](https://upload.wikimedia.org/wikipedia/commons/b/b5/En-Ubuntu_pronunciation.oga)  /ʊ'bʊntʊ/ | [🔊](https://upload.wikimedia.org/wikipedia/commons/b/b5/En-Ubuntu_pronunciation.oga)  /ʊ'bʊntʊ/ |  ❌ /juː'bʊntʊ/ |
 | UEFI | U-E-F-I | U-E-F-I  | ❌ /jufi/ /ɔːfi/ |
 | Vagrant | [🔊](https://dict.youdao.com/dictvoice?audio=Vagrant&type=1) /ˈveɪɡrənt/ | [🔊](https://dict.youdao.com/dictvoice?audio=Vagrant&type=2) /ˈveɪɡrənt/ | /ˈvagɹent/ |
 | variable | [🔊](https://dict.youdao.com/dictvoice?audio=variable&type=1)  /'veəriəbl/ | [🔊](https://dict.youdao.com/dictvoice?audio=variable&type=2)  /ˈveriəbl,ˈværiəbl/ | ❌ /və'raiəbl/ |

--- a/tools/chromium_extension/README.md
+++ b/tools/chromium_extension/README.md
@@ -1,5 +1,10 @@
 # 无页面跳转收听正确读音 的 chromium 扩展
 
+## 使用说明
+
+1. 点击第一列，调用的是搜索框页面
+1. 点击第二列和第三列，调用的播放音频功能
+
 ## [获得最新版扩展](https://github.com/jingjingxyk/chinese-programmer-wrong-pronunciation-chromium-extension.git)
 
 ## 手动安装扩展

--- a/tools/chromium_extension/js/app/init.js
+++ b/tools/chromium_extension/js/app/init.js
@@ -37,6 +37,10 @@ let init = () => {
           let aTag = event.target.parentNode.parentNode;
           audio_url = aTag.getAttribute("href");
         }
+        if (event.target.nodeName === "G-EMOJI") {
+          let aTag = event.target.parentNode;
+          audio_url = aTag.getAttribute("href");
+        }
         if (audio_url) {
           let desURL = new URL(audio_url);
           //console.log(desURL.protocol);


### PR DESCRIPTION
<!--
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
-->
