### PR TITLE
feat: add word chaos (#408)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 | BIOS | [🔊](https://dict.youdao.com/dictvoice?audio=bios&type=1)  /ˈbaɪɒs/ | /'baɪɑs/ |  ❌ /ˈbɪɒs/ |
 | cache | [🔊](https://dict.youdao.com/dictvoice?audio=cache&type=1)  /kæʃ/ | [🔊](https://dict.youdao.com/dictvoice?audio=cache&type=2)  /kæʃ/ |  ❌ /kætʃ/ |
 | canal | [🔊](https://dict.youdao.com/dictvoice?audio=canal&type=1) /kəˈnæl/ | [🔊](https://dict.youdao.com/dictvoice?audio=canal&type=2) /kəˈnæl/ | ❌ /ˈkænl/ |
-| chaos | [🔊](https://dict.youdao.com/dictvoice?audio=chaos&type=1) /ˈkeɪɒs/ | [🔊](https://dict.youdao.com/dictvoice?audio=chrome&type=2) /ˈkeɪɑːs/ |  ❌ /ˈtʃoʊs/ |
+| chaos | [🔊](https://dict.youdao.com/dictvoice?audio=chaos&type=1) /ˈkeɪɒs/ | [🔊](https://dict.youdao.com/dictvoice?audio=chaos&type=2) /ˈkeɪɑːs/ |  ❌ /ˈtʃoʊs/ |
 | Chrome | [🔊](https://dict.youdao.com/dictvoice?audio=chrome&type=1) /krəʊm/ | [🔊](https://dict.youdao.com/dictvoice?audio=chrome&type=2) /kroʊm/ |  ❌ /tʃɔːm/ |
 | clang | [🔊](https://dict.youdao.com/dictvoice?audio=clang&type=1)  /klæŋ/ | [🔊](https://dict.youdao.com/dictvoice?audio=clang&type=2)  /klæŋ/ |  ❌ /sɪlæŋ/ |
 | context | [🔊](https://dict.youdao.com/dictvoice?audio=context&type=1)  /ˈkɒntekst/ | [🔊](https://dict.youdao.com/dictvoice?audio=context&type=2)  / ˈkɑːntekst/ |  ❌ /kənˈtekst/ |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | BIOS | [🔊](https://dict.youdao.com/dictvoice?audio=bios&type=1)  /ˈbaɪɒs/ | /'baɪɑs/ |  ❌ /ˈbɪɒs/ |
 | cache | [🔊](https://dict.youdao.com/dictvoice?audio=cache&type=1)  /kæʃ/ | [🔊](https://dict.youdao.com/dictvoice?audio=cache&type=2)  /kæʃ/ |  ❌ /kætʃ/ |
 | canal | [🔊](https://dict.youdao.com/dictvoice?audio=canal&type=1) /kəˈnæl/ | [🔊](https://dict.youdao.com/dictvoice?audio=canal&type=2) /kəˈnæl/ | ❌ /ˈkænl/ |
+| chaos | [🔊](https://dict.youdao.com/dictvoice?audio=chaos&type=1) /ˈkeɪɒs/ | [🔊](https://dict.youdao.com/dictvoice?audio=chrome&type=2) /ˈkeɪɑːs/ |  ❌ /ˈtʃoʊs/ |
 | Chrome | [🔊](https://dict.youdao.com/dictvoice?audio=chrome&type=1) /krəʊm/ | [🔊](https://dict.youdao.com/dictvoice?audio=chrome&type=2) /kroʊm/ |  ❌ /tʃɔːm/ |
 | clang | [🔊](https://dict.youdao.com/dictvoice?audio=clang&type=1)  /klæŋ/ | [🔊](https://dict.youdao.com/dictvoice?audio=clang&type=2)  /klæŋ/ |  ❌ /sɪlæŋ/ |
 | context | [🔊](https://dict.youdao.com/dictvoice?audio=context&type=1)  /ˈkɒntekst/ | [🔊](https://dict.youdao.com/dictvoice?audio=context&type=2)  / ˈkɑːntekst/ |  ❌ /kənˈtekst/ |


### PR DESCRIPTION
<!--
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
-->
