### PR TITLE
feat: add word "migrate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 | maven | [🔊](https://dict.youdao.com/dictvoice?audio=maven&type=1)  /'meɪvn/ | [🔊](https://dict.youdao.com/dictvoice?audio=maven&type=2)  /ˈmeɪvn/ |  ❌ /'maːvn/ |
 | max | [🔊](https://dict.youdao.com/dictvoice?audio=max&type=1) /mæks/ | [🔊](https://dict.youdao.com/dictvoice?audio=max&type=2) /mæks/ |  ❌ /mɑ:ks/ |
 | Microsoft | [🔊](https://dict.youdao.com/dictvoice?audio=Microsoft&type=1)  /'maikrəusɔft/ | [🔊](https://dict.youdao.com/dictvoice?audio=Microsoft&type=2)  /ˈmaɪkrəsɔːft/ |  ❌ /'mikrəusɔft/ |
+| migrate | [🔊](https://dict.youdao.com/dictvoice?audio=migrate&type=1) /maɪˈɡreɪt/ | [🔊](https://dict.youdao.com/dictvoice?audio=migrate&type=2) /ˈmaɪɡreɪt/ |  ❌ /ˈmɪɡreɪt/ |
 | miscellaneous | [🔊](https://dict.youdao.com/dictvoice?audio=miscellaneous&type=1) /ˌmɪsəˈleɪniəs/ | [🔊](https://dict.youdao.com/dictvoice?audio=miscellaneous&type=2) /ˌmɪsəˈleɪniəs/ |  |
 | module | [🔊](https://dict.youdao.com/dictvoice?audio=module&type=1)  /'mɒdjuːl/ | [🔊](https://dict.youdao.com/dictvoice?audio=module&type=2)  /ˈmɑːdʒuːl/ |  ❌ /'məʊdl/ |
 | native | [🔊](https://dict.youdao.com/dictvoice?audio=native&type=1) /ˈneɪtɪv/ | [🔊](https://dict.youdao.com/dictvoice?audio=native&type=2) /ˈneɪtɪv/ | ❌ /ˈnætɪv/ |


### PR DESCRIPTION
add word "migrate"

<!--
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
-->
