### PR TITLE
feat: add new word "IEEE"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 | Haskell | [🔊](https://dict.youdao.com/dictvoice?audio=haskell&type=1)  /ˈhæskəl/ | [🔊](https://dict.youdao.com/dictvoice?audio=haskell&type=2)  /ˈhæskəl/ |  ❌ /hæˈskəl/ |
 | height | [🔊](https://dict.youdao.com/dictvoice?audio=height&type=1)  /haɪt/ | [🔊](https://dict.youdao.com/dictvoice?audio=height&type=2)  /haɪt/ |  ❌ /heɪt/ |
 | hidden | [🔊](https://dict.youdao.com/dictvoice?audio=hidden&type=1)  /'hɪdn/ | [🔊](https://dict.youdao.com/dictvoice?audio=hidden&type=2)  /ˈhɪdn/ |  ❌ /'haɪdn/ |
+| IEEE | [🔊](https://dict.youdao.com/dictvoice?audio=I_triple_e&type=1)  /aɪ ˈtrɪpəl i/ | [🔊](https://dict.youdao.com/dictvoice?audio=I_triple_e&type=2)  /aɪ ˈtrɪpəl i/ |  ❌ /'aɪ'iː'iː'iː/ |
 | image | [🔊](https://dict.youdao.com/dictvoice?audio=image&type=1)  /'ɪmɪdʒ/ | [🔊](https://dict.youdao.com/dictvoice?audio=image&type=2)  /ˈɪmɪdʒ/ |  ❌ /ɪ'meɪdʒ/ |
 | implement | [🔊](https://dict.youdao.com/dictvoice?audio=implement&type=1)  /'ɪmplɪm(ə)nt/ | [🔊](https://dict.youdao.com/dictvoice?audio=implement&type=2)  /ˈɪmplɪmənt/ /ˈɪmpləˌment/ |  ❌ /ɪm'plem(ə)nt/ |
 | integer | [🔊](https://dict.youdao.com/dictvoice?audio=integer&type=1)  /'ɪntɪdʒə/ | [🔊](https://dict.youdao.com/dictvoice?audio=integer&type=2)  /ˈɪntɪdʒər/ |  ❌ /ˈɪntaɪgə/ |


### PR DESCRIPTION
IEEE 美国电气和电子工程师协会，应该是每个程序员都绕不开的单词吧，学组成原理有 IEEE 754，学计网有 IEEE 802.3。
而且不加说明，很多人第一次一定会读错的哈。
<!--
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
-->
