### PR TITLE
Add Bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | async | [🔊](https://dict.youdao.com/dictvoice?audio=async&type=1) /əˈsɪŋk/ | [🔊](https://dict.youdao.com/dictvoice?audio=async&type=2) /æˈsɪŋk/ | ❌ /'æsɪŋk/ |
 | avatar | [🔊](https://dict.youdao.com/dictvoice?audio=avatar&type=1)  /'ævətɑː/ | [🔊](https://dict.youdao.com/dictvoice?audio=avatar&type=2)  /ˈævətɑːr/ |  ❌ /ə'vʌtɑ/ |
 | Azure | [🔊](https://dict.youdao.com/dictvoice?audio=azure&type=1)  /'æʒə/ | [🔊](https://dict.youdao.com/dictvoice?audio=azure&type=2)  /ˈæʒər/ |  ❌ /ˈæzʊʒə/ |
+| Bazel | [🔊](https://dict.youdao.com/dictvoice?audio=bazel&type=1)  /ˈbeɪzəl/ | [🔊](https://dict.youdao.com/dictvoice?audio=bazel&type=1) /ˈbeɪzəl/ |  ❌ /bæ zəl/ |
 | bind | [🔊](https://dict.youdao.com/dictvoice?audio=bind&type=1)  /baɪnd/ | [🔊](https://dict.youdao.com/dictvoice?audio=bind&type=2)  /baɪnd/ |  ❌ /bɪnd/ |
 | BIOS | [🔊](https://dict.youdao.com/dictvoice?audio=bios&type=1)  /ˈbaɪɒs/ | /'baɪɑs/ |  ❌ /ˈbɪɒs/ |
 | cache | [🔊](https://dict.youdao.com/dictvoice?audio=cache&type=1)  /kæʃ/ | [🔊](https://dict.youdao.com/dictvoice?audio=cache&type=2)  /kæʃ/ |  ❌ /kætʃ/ |


### PR DESCRIPTION
<!--
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
-->
Add `Bazel` [/ˈbeɪzəl/]  https://en.wikipedia.org/wiki/Bazel_(software)