### PR TITLE
Add RISC-V

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 | resolved | [🔊](https://dict.youdao.com/dictvoice?audio=resolved&type=1)  /rɪ'zɒlvd/ | [🔊](https://dict.youdao.com/dictvoice?audio=resolved&type=2)  /rɪˈzɑːlvd/ |  ❌ /rɪ'səʊvd/ |
 | resort | [🔊](https://dict.youdao.com/dictvoice?audio=resort&type=1)  /rɪˈzɔ:t/ | [🔊](https://dict.youdao.com/dictvoice?audio=resort&type=2)  /rɪˈzɔːrt/ |  ❌ /rɪˈsɔ:t/ |
 | retina | [🔊](https://dict.youdao.com/dictvoice?audio=retina&type=1)  /'retɪnə/ | [🔊](https://dict.youdao.com/dictvoice?audio=retina&type=2)  /ˈretɪnə/ |  ❌ /ri'tina/ |
+| RISC-V | [🔊](https://dict.youdao.com/dictvoice?audio=risk-five&type=1)  /'rɪsk faɪv/ | [🔊](https://dict.youdao.com/dictvoice?audio=risk-five&type=2)  /'rɪsk faɪv/ |  ❌ /'rɪsk v/ |
 | route | [🔊](https://dict.youdao.com/dictvoice?audio=route&type=1)  /ruːt/ | [🔊](https://dict.youdao.com/dictvoice?audio=route&type=2)  /ruːt,raʊt/ |  ❌ /rəʊt/ |
 | San Jose | [🔊](https://dict.youdao.com/dictvoice?audio=san%20jose&type=1)  /sænhəu'zei/ | [🔊](https://dict.youdao.com/dictvoice?audio=san%20jose&type=2)  /sænhəu'zei/ |  ❌ /sæn'ju:s/ |
 | safari | [🔊](https://dict.youdao.com/dictvoice?audio=safari&type=1)  /sə'fɑːrɪ/ | [🔊](https://dict.youdao.com/dictvoice?audio=safari&type=2)  /səˈfɑːri/ |  ❌ /sæfərɪ/ |


### PR DESCRIPTION
Add `RISC-V`. The correct pronunciation is "risk five", not "risk v".

<!--
PR说明:
1. 尽量提交常用的单词和中国程序员容易读错的单词。
1. 选择合适的Labels。
1. 音标目前为[海词](http://dict.cn/)英式发音, 使用 [DJ 音标写法](https://zh.wikipedia.org/wiki/DJ%E9%9F%B3%E6%A8%99)。
1. 音频地址 英音：http://dict.youdao.com/dictvoice?audio=${word}&type=1，美音：http://dict.youdao.com/dictvoice?audio=${word}&type=2 ，如果没有或者发音不准确再使用其他音频。
1. 音标到这个有道网页找 http://dict.youdao.com/w/eng/{word}。
1. 音标使用斜线 `/.../`。
1. tools目录下有个python程序可以从有道网站创建单词信息。
   - Usage: `tools/addword.py <word>`
-->
